### PR TITLE
Upgrade to support pangeo-forge-recipes 0.4.0 release api changes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="pangeo_forge_prefect",
     packages=find_packages(),
     install_requires=[
-        "pangeo-forge-recipes>=0.3.3",
+        "pangeo-forge-recipes>=0.4.0",
         "pyyaml==5.4.1",
         "prefect[aws]>=0.14.13",
         "dacite==1.6.0",

--- a/test/data/bakeries.yaml
+++ b/test/data/bakeries.yaml
@@ -2,7 +2,7 @@
 devseed.bakery.development.aws.us-west-2:
   region: aws.us-west-2
   targets:
-    pangeo-forge-aws-bakery-flowcachebucketpangeofor-196cpck7y0pbl:
+    pangeo-forge-aws-bakery-flowcachebucketdasktest4-10neo67y7a924:
       region: aws.us-west-2
       description: "Internal bucket"
       private:
@@ -12,18 +12,18 @@ devseed.bakery.development.aws.us-west-2:
           secret: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_SECRET
   cluster:
     type: aws.fargate
-    pangeo_forge_version: "0.3.3"
-    pangeo_notebook_version: "2021.05.04"
-    prefect_version: "0.14.7"
-    worker_image: 552819999234.dkr.ecr.us-west-2.amazonaws.com/pangeo-forge-aws-bakery-worker
+    pangeo_forge_version: "0.4.0"
+    pangeo_notebook_version: "2021.06.05"
+    prefect_version: "0.14.22"
+    worker_image: pangeo/pangeo-forge-bakery-images:pangeonotebook-2021.06.05_prefect-0.14.22_pangeoforgerecipes-0.4.0
     cluster_options:
-      vpc: vpc-0e519fd83fa521d72
-      cluster_arn: arn:aws:ecs:us-west-2:552819999234:cluster/pangeo-forge-aws-bakery-pangeo-forge-dask-bakeryclusterpangeoforgedask71B831F8-BTL3Vmp8cuso
-      task_role_arn: arn:aws:iam::552819999234:role/pangeo-forge-aws-bakery-p-prefectecstaskrolepangeo-3R73K3Z1XU70
-      execution_role_arn: arn:aws:iam::552819999234:role/pangeo-forge-aws-bakery-p-prefectecstaskexecutionr-5ZGMH0A8LVXF
+      vpc: vpc-01160815e8310bbe0
+      cluster_arn: arn:aws:ecs:us-west-2:552819999234:cluster/pangeo-forge-aws-bakery-dask-test-bakeryclusterdasktest4E1A8264-k6Cnpc8EuUpH
+      task_role_arn: arn:aws:iam::552819999234:role/pangeo-forge-aws-bakery-d-prefectecstaskroledaskte-XUA2HGW10IJV
+      execution_role_arn: arn:aws:iam::552819999234:role/pangeo-forge-aws-bakery-d-prefectecstaskexecutionr-KLL5UEHNBF8Z
       security_groups:
-        - sg-0c4d6e997637c801d
-    flow_storage: pangeo-forge-aws-bakery-flowstoragebucketpangeof-71w6gsnambj9
+        - sg-0ca6b9d46294e5623
+    flow_storage: pangeo-forge-aws-bakery-flowstoragebucketdasktes-1bchocmkc3w0
     flow_storage_protocol: s3
     flow_storage_options:
       key: DEVSEED_BAKERY_DEVELOPMENT_AWS_US_WEST_2_KEY
@@ -41,10 +41,10 @@ devseed.bakery.development.azure.ukwest:
           secret: DEVSEED_BAKERY_DEVELOPMENT_AZURE_UKWEST_CONNECTION_STRING
   cluster:
     type: azure.aks
-    pangeo_forge_version: "0.3.4"
-    pangeo_notebook_version: "2021.05.15"
-    prefect_version: "0.14.19"
-    worker_image: pangeo/pangeo-forge-bakery-images:pangeonotebook-2021.05.15_prefect-0.14.19_pangeoforgerecipes-0.3.4
+    pangeo_forge_version: "0.4.0"
+    pangeo_notebook_version: "2021.06.05"
+    prefect_version: "0.14.22"
+    worker_image: pangeo/pangeo-forge-bakery-images:pangeonotebook-2021.06.05_prefect-0.14.22_pangeoforgerecipes-0.4.0
     flow_storage: test-bakery-flow-storage-container
     flow_storage_protocol: abfs
     flow_storage_options:

--- a/test/data/meta_aws.yaml
+++ b/test/data/meta_aws.yaml
@@ -1,7 +1,7 @@
 title: "NOAA Optimum Interpolated SST"
 description: "Analysis-ready Zarr datasets derived from NOAA OISST NetCDF"
-pangeo_forge_version: "0.3.3"
-pangeo_notebook_version: "2021.05.04"
+pangeo_forge_version: "0.4.0"
+pangeo_notebook_version: "2021.06.05"
 recipes:
   - id: noaa-oisst-avhrr-only
     object: "recipe:recipe"
@@ -20,7 +20,7 @@ maintainers:
     github: rabernat
 bakery:
   id: "devseed.bakery.development.aws.us-west-2"  # must come from a valid list of bakeries
-  target: pangeo-forge-aws-bakery-flowcachebucketpangeofor-196cpck7y0pbl
+  target: pangeo-forge-aws-bakery-flowcachebucketdasktest4-10neo67y7a924
   resources:
     memory: 4096
     cpu: 1024

--- a/test/data/recipe.py
+++ b/test/data/recipe.py
@@ -1,16 +1,31 @@
 import pandas as pd
-from pangeo_forge_recipes.patterns import pattern_from_file_sequence
+
+#  from pangeo_forge_recipes.patterns import pattern_from_file_sequence
+from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
 
-input_url_pattern = (
-    "https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation"
-    "/v2.1/access/avhrr/{yyyymm}/oisst-avhrr-v02r01.{yyyymmdd}.nc"
-)
-dates = pd.date_range("2019-09-01", "2021-01-05", freq="D")
-input_urls = [
-    input_url_pattern.format(yyyymm=day.strftime("%Y%m"), yyyymmdd=day.strftime("%Y%m%d"))
-    for day in dates
-]
-pattern = pattern_from_file_sequence(input_urls, "time", nitems_per_file=1)
+#  input_url_pattern = (
+#  "https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation"
+#  "/v2.1/access/avhrr/{yyyymm}/oisst-avhrr-v02r01.{yyyymmdd}.nc"
+#  )
+#  dates = pd.date_range("2019-09-01", "2021-01-05", freq="D")
+#  input_urls = [
+#  input_url_pattern.format(yyyymm=day.strftime("%Y%m"), yyyymmdd=day.strftime("%Y%m%d"))
+#  for day in dates
+#  ]
 
-recipe = XarrayZarrRecipe(pattern, inputs_per_chunk=20)
+
+def format_function(time):
+    base = pd.Timestamp("2019-09-01")
+    day = base + pd.Timedelta(days=time)
+    input_url_pattern = (
+        "https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation"
+        "/v2.1/access/avhrr/{day:%Y%m}/oisst-avhrr-v02r01.{day:%Y%m%d}.nc"
+    )
+    return input_url_pattern.format(day=day)
+
+
+dates = pd.date_range("2019-09-01", "2021-01-05", freq="D")
+#  pattern = pattern_from_file_sequence(input_urls, "time", nitems_per_file=1)
+pattern = FilePattern(format_function, ConcatDim("time", range(len(dates)), 1))
+recipe = XarrayZarrRecipe(pattern, inputs_per_chunk=20, cache_inputs=True)

--- a/test/data/recipe.py
+++ b/test/data/recipe.py
@@ -1,18 +1,6 @@
 import pandas as pd
-
-#  from pangeo_forge_recipes.patterns import pattern_from_file_sequence
 from pangeo_forge_recipes.patterns import ConcatDim, FilePattern
 from pangeo_forge_recipes.recipes import XarrayZarrRecipe
-
-#  input_url_pattern = (
-#  "https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation"
-#  "/v2.1/access/avhrr/{yyyymm}/oisst-avhrr-v02r01.{yyyymmdd}.nc"
-#  )
-#  dates = pd.date_range("2019-09-01", "2021-01-05", freq="D")
-#  input_urls = [
-#  input_url_pattern.format(yyyymm=day.strftime("%Y%m"), yyyymmdd=day.strftime("%Y%m%d"))
-#  for day in dates
-#  ]
 
 
 def format_function(time):
@@ -26,6 +14,5 @@ def format_function(time):
 
 
 dates = pd.date_range("2019-09-01", "2021-01-05", freq="D")
-#  pattern = pattern_from_file_sequence(input_urls, "time", nitems_per_file=1)
 pattern = FilePattern(format_function, ConcatDim("time", range(len(dates)), 1))
 recipe = XarrayZarrRecipe(pattern, inputs_per_chunk=20, cache_inputs=True)

--- a/test/test_flow_manager.py
+++ b/test/test_flow_manager.py
@@ -139,7 +139,7 @@ def test_configure_targets_aws(S3FileSystem, aws_bakery, meta_aws, secrets):
         f"s3://{meta_aws.bakery.target}/pangeo-forge/staged-recipes/{recipe_name}.zarr"
     )
     aws_bakery.targets[
-        "pangeo-forge-aws-bakery-flowcachebucketpangeofor-196cpck7y0pbl"
+        "pangeo-forge-aws-bakery-flowcachebucketdasktest4-10neo67y7a924"
     ].private.protocol = "GCS"
     with pytest.raises(UnsupportedTarget):
         configure_targets(aws_bakery, meta_aws.bakery, recipe_name, secrets, extension)
@@ -264,9 +264,9 @@ def test_configure_run_config_azure(azure_bakery, meta_azure, k8s_job_template, 
 
 def test_check_versions(aws_bakery, meta_aws):
     versions = Versions(
-        pangeo_notebook_version="2021.05.04",
-        pangeo_forge_version="0.3.3",
-        prefect_version="0.14.7",
+        pangeo_notebook_version="2021.06.05",
+        pangeo_forge_version="0.4.0",
+        prefect_version="0.14.22",
     )
     assert check_versions(meta_aws, aws_bakery.cluster, versions)
     versions.pangeo_notebook_version = "none"


### PR DESCRIPTION
## What I am changing
Upgrade to support pangeo-forge-recipes 0.4.0 release api changes.

## How I did it
Changed the internal mechanics of `recipe_to_flow` to use `BaseRecipe`'s new `to_recipe` method.
Extended test coverage for the `recipe_to_flow` method.
Refactored the example `recipe` to use the new recommend approach for file patterns outlined [here](https://github.com/pangeo-forge/pangeo-forge-recipes/pull/160#issuecomment-864075050
Updated the sample `meta.yaml` and `bakeries.yaml` files to align with the actual values in https://github.com/pangeo-forge/bakery-database.

## How you can test it
Run the unit tests.