### PR TITLE
Prefect Automations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ PREFECT_PROJECT_NAME
 ```
 To be set to the Pangeo Forge Prefect Cloud [project](https://docs.prefect.io/orchestration/concepts/projects.html#projects) name.
 
+The environment variable
+```
+GITHUB_REPOSITORY
+```
+Should be the repository which triggers the Flow registration.
+
+If the environment variable
+```
+COMMENT_ID
+```
+is present a notification hook will be registered for the Flow completion status.
+
 
 ## Install
 From source

--- a/pangeo_forge_prefect/automation_hook_manager.py
+++ b/pangeo_forge_prefect/automation_hook_manager.py
@@ -1,0 +1,74 @@
+import json
+import os
+
+from prefect.client.client import Client
+from prefect.utilities.graphql import with_args
+
+client = Client()
+
+
+def new_automation(flow_group_id, pat_token):
+    payload = {
+        "event_type": "prefect_webhook",
+        "client_payload": {
+            "state": "{state}",
+            "flow_run_id": "{flow_run_id}",
+        },
+    }
+    headers = {"Authorization": f"token {pat_token}", "Accept": "application/vnd.github.v3+json"}
+
+    payload_string = json.dumps(payload)
+    headers_string = json.dumps(headers)
+
+    repository = os.environ["GITHUB_REPOSITORY"]
+    create_action = {
+        "mutation": {
+            with_args(
+                "create_action",
+                {
+                    "input": {
+                        "config": {
+                            "webhook": {
+                                "url": f"https://api.github.com/repos/{repository}/dispatches",
+                                "payload": payload_string,
+                                "headers": headers_string,
+                            }
+                        }
+                    }
+                },
+            ): {"id"}
+        }
+    }
+    action_response = client.graphql(create_action)
+    action_id = action_response["data"]["create_action"]["id"]
+
+    create_flow_run_state_changed_hook = {
+        "mutation": {
+            with_args(
+                "create_flow_run_state_changed_hook",
+                {
+                    "input": {
+                        "action_id": action_id,
+                        "flow_group_ids": [flow_group_id],
+                        "states": ["Success", "Failed"],
+                    }
+                },
+            ): {"id"}
+        }
+    }
+    hook_id = client.graphql(create_flow_run_state_changed_hook)
+    print(hook_id)
+
+
+def create_automation(flow_id, pat_token):
+    flow_group_id_query = {
+        "query": {
+            with_args("flow", {"where": {"id": {"_eq": flow_id}}}): {
+                "flow_group_id",
+                "version_group_id",
+            }
+        }
+    }
+    flow_group_id_response = client.graphql(flow_group_id_query)
+    flow_group_id = flow_group_id_response["data"]["flow"][0]["flow_group_id"]
+    new_automation(flow_group_id, pat_token)

--- a/pangeo_forge_prefect/automation_hook_manager.py
+++ b/pangeo_forge_prefect/automation_hook_manager.py
@@ -61,6 +61,21 @@ def new_automation(flow_group_id, pat_token):
 
 
 def create_automation(flow_id, pat_token):
+    """
+    Create a Prefect Automation to call a Github repository webhook.
+
+    Create a Prefect Automation that POSTs to a Github repository webhook
+    when a test flow is registered.  The Github Action usess the flow_run_id
+    (which is set to the trigger comment's id) to update the comment when the
+    test flow run succeeds or fails.
+
+    Parameters
+    ----------
+    flow_id : str
+        The id of the registered flow
+    pat_token : str
+        A Github PAT token with at a minimum the repo scope.
+    """
     flow_group_id_query = {
         "query": {
             with_args("flow", {"where": {"id": {"_eq": flow_id}}}): {
@@ -71,4 +86,15 @@ def create_automation(flow_id, pat_token):
     }
     flow_group_id_response = client.graphql(flow_group_id_query)
     flow_group_id = flow_group_id_response["data"]["flow"][0]["flow_group_id"]
-    new_automation(flow_group_id, pat_token)
+
+    hook_query = {
+        "query": {
+            with_args(
+                "hook", {"where": {"event_tags": {"_contains": {"flow_group_id": [flow_group_id]}}}}
+            ): {"id"}
+        }
+    }
+    hook_query_response = client.graphql(hook_query)
+    hook_exists = len(hook_query_response["data"]["hook"]) > 0
+    if not hook_exists:
+        new_automation(flow_group_id, pat_token)

--- a/test/test_automation_hook_manager.py
+++ b/test/test_automation_hook_manager.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch
+
+from pangeo_forge_prefect.automation_hook_manager import create_automation
+
+
+@patch("pangeo_forge_prefect.automation_hook_manager.new_automation")
+@patch("pangeo_forge_prefect.automation_hook_manager.client")
+def test_create_automation(client, new_automation):
+    flow_group_id = "flow_group_id"
+    flow_qroup_query_response = {"data": {"flow": [{"flow_group_id": flow_group_id}]}}
+    hook_query_response = {"data": {"hook": []}}
+    client.graphql.side_effect = [flow_qroup_query_response, hook_query_response]
+    create_automation("", "")
+    new_automation.assert_called_once_with(flow_group_id, "")


### PR DESCRIPTION
## What I am changing
Adding the option to create a Prefect Automation after registering flow.  This Automation will update the comment where registration was triggered by a slash-command when the test flow completes with a Success or Failed state.

## How I did it
Used Prefect's GraphQL API to register a custom action and event hook which calls a Github repository's dispatch webhook.  The test flow uses the triggering comment's id as a flow run id to maintain a linkage to the comment.  There will be a corresponding PR in https://github.com/pangeo-forge/staged-recipes to include the comment update workflow.

## How you can test it
Given the requirement for a flow to actually be run to trigger an Automation event and the requirement for a target webhook listener to be configured, integration testing for this feature is difficult to achieve.  I have run integration successfully using a temporary target repo configured with the comment update workflow.