### PR TITLE
Use MALLOC_TRIM_THRESHOLD_ setting to reduce unmanaged memory usage.

### DIFF
--- a/pangeo_forge_prefect/flow_manager.py
+++ b/pangeo_forge_prefect/flow_manager.py
@@ -136,7 +136,10 @@ def configure_dask_executor(
                 "worker_cpu": worker_cpu,
                 "worker_mem": worker_mem,
                 "scheduler_timeout": "15 minutes",
-                "environment": {"PREFECT__LOGGING__EXTRA_LOGGERS": "['pangeo_forge_recipes']"},
+                "environment": {
+                    "PREFECT__LOGGING__EXTRA_LOGGERS": "['pangeo_forge_recipes']",
+                    "MALLOC_TRIM_THRESHOLD_": "0",
+                },
                 "tags": {
                     "Project": "pangeo-forge",
                     "Recipe": recipe_name,


### PR DESCRIPTION
## What I am changing
Using the `MALLOC_TRIM_THRESHOLD_` environment setting to reduce worker unmanaged memory usage. See https://distributed.dask.org/en/latest/worker.html#automatically-trim-memory

## How I did it

## How you can test it
